### PR TITLE
user left_outer_joins instead of joins for more complete results

### DIFF
--- a/lib/association_count.rb
+++ b/lib/association_count.rb
@@ -9,7 +9,7 @@ module AssociationCount
     counted_name  = counted_table.singularize
     distinct_sql  = distinct ? 'DISTINCT' : ''
 
-    joins(counted_table.to_sym)
+    left_outer_joins(counted_table.to_sym)
       .select("#{table_name}.*, COUNT(#{distinct_sql} #{counted_table}.id) as #{counted_name}_count_raw")
       .group("#{table_name}.id")
   end


### PR DESCRIPTION
This users left_outer_joins instead of joins so that associations with zero associated records are included in the results.

Resolves https://github.com/trialbee/association_count/issues/6
