### PR TITLE
split select into two terms

### DIFF
--- a/lib/association_count.rb
+++ b/lib/association_count.rb
@@ -12,7 +12,7 @@ module AssociationCount
     distinct_sql  = distinct ? 'DISTINCT' : ''
 
     public_send(join_type, counted_table.to_sym)
-      .select("#{table_name}.*, COUNT(#{distinct_sql} #{counted_table}.id) as #{counted_name}_count_raw")
+      .select("#{table_name}.*").select("COUNT(#{distinct_sql} #{counted_table}.id) as #{counted_name}_count_raw")
       .group("#{table_name}.id")
   end
 


### PR DESCRIPTION
At present, if a model has two `can_count` associations setup, a query for both at the same time will `select table.*` twice.

```ruby
class Product < ActiveRecord::Base
  has_many :reviews
  has_many :photos
  can_count :reviews
  can_count :photos
end

Product.include_review_count.include_photos_count
```
Will yield a query like:
```sql
SELECT 
  products.*, 
  COUNT(reviews.id) as review_count_raw, 
  products.*,
  COUNT(photos.id) as photo_count_raw 
FROM ...
```

With this patch, it will generate a query like:
```sql
SELECT 
  products.*, 
  COUNT(reviews.id) as review_count_raw, 
  COUNT(photos.id) as photo_count_raw 
FROM ...
```

By separating the `select(#{table_name}.*")` from the `select("count")`, ActiveRecord is able to de-duplicate the select clauses at query generation time, which saves the database from querying out and transferring the same data twice.  I suspect this would have a large memory impact in rails for large data sets, but have not tested that.